### PR TITLE
Update editor draft URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
 			JF2 is a json serialization format.  It is compact and directly parsable from pages marked up with Microformats.
 		</p>
 		<p>
-			<a href="http://dissolve.github.io/jf2/">Current Editor's Draft</a>
+			<a href="https://jf2.spec.indieweb.org/">Current Editor's Draft</a>
 		</p>
 		<p>
 			<a href="http://www.w3.org/TR/jf2/">Latest Published Draft</a>
@@ -27,7 +27,7 @@
 			JF2 Feed is a subset of JF2.  It is specifically designed to be similar to RSS, ATOM, and JSONFeeds, but using microformats vocabulary.  This way it is parsable directly from a microformats h-feed!
 		</p>
 		<p>
-			<a href="http://dissolve.github.io/jf2/#jf2feed">Current Editor's Draft</a>
+			<a href="https://jf2.spec.indieweb.org/#jf2feed">Current Editor's Draft</a>
 		</p>
 		<p>
 			<a href="http://www.w3.org/TR/jf2/#jf2feed">Latest Published Draft</a>


### PR DESCRIPTION
The URL for the editor draft has moved and currently following the link causes a HTTP 404 error. To reduce confussion, this PR updates the target of those links with the new editor draft location. Both the editor draft and the J2Feed draft links are updated.